### PR TITLE
Fix wrong key for active programs cache

### DIFF
--- a/lib/controller/setting_controller.dart
+++ b/lib/controller/setting_controller.dart
@@ -3,7 +3,7 @@ import 'package:get/get.dart';
 
 class SettingController extends GetxController {
   static const keyOnlyActiveOnSpecificPrograms = 'onlyActiveOnSpecificPrograms';
-  static const keyActivePrograms = 'onlyActiveOnSpecificPrograms';
+  static const keyActivePrograms = 'activePrograms';
   static const keyClickDelay = 'clickDelay';
 
   final onlyActiveOnSpecificPrograms = false.obs;
@@ -18,7 +18,7 @@ class SettingController extends GetxController {
 
   void _initAsync() async {
     final onlyActiveOnSpecificProgramsValue = await CacheManager.get<bool>(keyOnlyActiveOnSpecificPrograms) ?? false;
-    final activeProgramsValue = await CacheManager.get<List<String>>(keyActivePrograms) ?? <String>[];
+    final activeProgramsValue = await CacheManager.getList<String>(keyActivePrograms) ?? <String>[];
 
     onlyActiveOnSpecificPrograms.value = onlyActiveOnSpecificProgramsValue;
     activePrograms.value = activeProgramsValue;


### PR DESCRIPTION
## Summary
- fix cache key name for `activePrograms`
- load active programs using `getList`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68411097f80c832faa536955f2d49f5b